### PR TITLE
remove unused legacy Shapes from Model and friends

### DIFF
--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -431,15 +431,17 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
             }
         }
 
+        /*
+        // TODO: re-implement these when we have more detailed avatar collision shapes
         bool renderSkeleton = Menu::getInstance()->isOptionChecked(MenuOption::RenderSkeletonCollisionShapes);
-        bool renderHead = Menu::getInstance()->isOptionChecked(MenuOption::RenderHeadCollisionShapes);
-        bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
         if (renderSkeleton) {
-            _skeletonModel.renderJointCollisionShapes(0.7f);
         }
+        bool renderHead = Menu::getInstance()->isOptionChecked(MenuOption::RenderHeadCollisionShapes);
         if (renderHead && shouldRenderHead(renderArgs)) {
-            getHead()->getFaceModel().renderJointCollisionShapes(0.7f);
         }
+        */
+
+        bool renderBounding = Menu::getInstance()->isOptionChecked(MenuOption::RenderBoundingCollisionShapes);
         if (renderBounding && shouldRenderHead(renderArgs)) {
             _skeletonModel.renderBoundingCollisionShapes(*renderArgs->_batch, 0.7f);
         }
@@ -792,33 +794,6 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& frustum, co
     textTransform.postTranslate(glm::vec3(0.0f, 0.0f, SLIGHTLY_IN_FRONT * renderer->getFontSize()));
     batch.setModelTransform(textTransform);
     renderer->draw(batch, text_x, -text_y, nameUTF8.data(), textColor);
-}
-
-bool Avatar::findRayIntersection(RayIntersectionInfo& intersection) const {
-    bool hit = _skeletonModel.findRayIntersection(intersection);
-    hit = getHead()->getFaceModel().findRayIntersection(intersection) || hit;
-    return hit;
-}
-
-bool Avatar::findSphereCollisions(const glm::vec3& penetratorCenter, float penetratorRadius, CollisionList& collisions) {
-    return _skeletonModel.findSphereCollisions(penetratorCenter, penetratorRadius, collisions);
-    // TODO: Andrew to fix: Temporarily disabling collisions against the head
-    //return getHead()->getFaceModel().findSphereCollisions(penetratorCenter, penetratorRadius, collisions);
-}
-
-bool Avatar::findPlaneCollisions(const glm::vec4& plane, CollisionList& collisions) {
-    return _skeletonModel.findPlaneCollisions(plane, collisions) ||
-        getHead()->getFaceModel().findPlaneCollisions(plane, collisions);
-}
-
-bool Avatar::findCollisions(const QVector<const Shape*>& shapes, CollisionList& collisions) {
-    // TODO: Andrew to fix: also collide against _skeleton
-    //bool collided = _skeletonModel.findCollisions(shapes, collisions);
-
-    Model& headModel = getHead()->getFaceModel();
-    //collided = headModel.findCollisions(shapes, collisions) || collided;
-    bool collided = headModel.findCollisions(shapes, collisions);
-    return collided;
 }
 
 void Avatar::setSkeletonOffset(const glm::vec3& offset) {

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -1115,9 +1115,8 @@ void Avatar::setShowDisplayName(bool showDisplayName) {
 
 // virtual
 void Avatar::computeShapeInfo(ShapeInfo& shapeInfo) {
-    const CapsuleShape& capsule = _skeletonModel.getBoundingShape();
-    shapeInfo.setCapsuleY(capsule.getRadius(), capsule.getHalfHeight());
-    shapeInfo.setOffset(_skeletonModel.getBoundingShapeOffset());
+    shapeInfo.setCapsuleY(_skeletonModel.getBoundingCapsuleRadius(), 0.5f * _skeletonModel.getBoundingCapsuleHeight());
+    shapeInfo.setOffset(_skeletonModel.getBoundingCapsuleOffset());
 }
 
 // virtual

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -110,26 +110,6 @@ public:
     /// Returns the distance to use as a LOD parameter.
     float getLODDistance() const;
 
-    bool findRayIntersection(RayIntersectionInfo& intersection) const;
-
-    /// \param shapes list of shapes to collide against avatar
-    /// \param collisions list to store collision results
-    /// \return true if at least one shape collided with avatar
-    bool findCollisions(const QVector<const Shape*>& shapes, CollisionList& collisions);
-
-    /// Checks for penetration between the a sphere and the avatar's models.
-    /// \param penetratorCenter the center of the penetration test sphere
-    /// \param penetratorRadius the radius of the penetration test sphere
-    /// \param collisions[out] a list to which collisions get appended
-    /// \return whether or not the sphere penetrated
-    bool findSphereCollisions(const glm::vec3& penetratorCenter, float penetratorRadius, CollisionList& collisions);
-
-    /// Checks for penetration between the described plane and the avatar.
-    /// \param plane the penetration plane
-    /// \param collisions[out] a list to which collisions get appended
-    /// \return whether or not the plane penetrated
-    bool findPlaneCollisions(const glm::vec4& plane, CollisionList& collisions);
-
     virtual bool isMyAvatar() const { return false; }
     
     virtual QVector<glm::quat> getJointRotations() const;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1088,11 +1088,10 @@ glm::vec3 MyAvatar::getSkeletonPosition() const {
 
 void MyAvatar::rebuildSkeletonBody() {
     // compute localAABox
-    const CapsuleShape& capsule = _skeletonModel.getBoundingShape();
-    float radius = capsule.getRadius();
-    float height = 2.0f * (capsule.getHalfHeight() + radius);
+    float radius = _skeletonModel.getBoundingCapsuleRadius();
+    float height = _skeletonModel.getBoundingCapsuleHeight() + 2.0f * radius;
     glm::vec3 corner(-radius, -0.5f * height, -radius);
-    corner += _skeletonModel.getBoundingShapeOffset();
+    corner += _skeletonModel.getBoundingCapsuleOffset();
     glm::vec3 scale(2.0f * radius, height, 2.0f * radius);
     _characterController.setLocalBoundingBox(corner, scale);
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -110,8 +110,6 @@ MyAvatar::MyAvatar(RigPointer rig) :
         _driveKeys[i] = 0.0f;
     }
 
-    _skeletonModel.setEnableShapes(true);
-
     // connect to AddressManager signal for location jumps
     connect(DependencyManager::get<AddressManager>().data(), &AddressManager::locationChangeRequired,
             this, &MyAvatar::goToLocation);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -12,9 +12,7 @@
 #include <glm/gtx/transform.hpp>
 #include <QMultiMap>
 
-#include <CapsuleShape.h>
 #include <DeferredLightingEffect.h>
-#include <SphereShape.h>
 
 #include "Application.h"
 #include "Avatar.h"
@@ -44,7 +42,6 @@ SkeletonModel::SkeletonModel(Avatar* owningAvatar, QObject* parent, RigPointer r
 {
     assert(_rig);
     assert(_owningAvatar);
-    _enableShapes = true;
 }
 
 SkeletonModel::~SkeletonModel() {
@@ -81,10 +78,7 @@ void SkeletonModel::initJointStates(QVector<JointState> states) {
         _rig->updateJointState(i, parentTransform);
     }
 
-    clearShapes();
-    if (_enableShapes) {
-        buildShapes();
-    }
+    buildShapes();
 
     Extents meshExtents = getMeshExtents();
     _headClipDistance = -(meshExtents.minimum.z / _scale.z - _defaultEyeModelPosition.z);

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -32,8 +32,9 @@ SkeletonModel::SkeletonModel(Avatar* owningAvatar, QObject* parent, RigPointer r
     Model(rig, parent),
     _triangleFanID(DependencyManager::get<GeometryCache>()->allocateID()),
     _owningAvatar(owningAvatar),
-    _boundingShape(),
-    _boundingShapeLocalOffset(0.0f),
+    _boundingCapsuleLocalOffset(0.0f),
+    _boundingCapsuleRadius(0.0f),
+    _boundingCapsuleHeight(0.0f),
     _defaultEyeModelPosition(glm::vec3(0.0f, 0.0f, 0.0f)),
     _standingFoot(NO_FOOT),
     _standingOffset(0.0f),
@@ -177,9 +178,6 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
     if (_rig->getJointsAreDirty()) {
         updateClusterMatrices();
     }
-
-    _boundingShape.setTranslation(_translation + _rotation * _boundingShapeLocalOffset);
-    _boundingShape.setRotation(_rotation);
 }
 
 void SkeletonModel::renderIKConstraints(gpu::Batch& batch) {
@@ -671,12 +669,11 @@ void SkeletonModel::computeBoundingShape(const FBXGeometry& geometry) {
     // NOTE: we assume that the longest side of totalExtents is the yAxis...
     glm::vec3 diagonal = totalExtents.maximum - totalExtents.minimum;
     // ... and assume the radius is half the RMS of the X and Z sides:
-    float capsuleRadius = 0.5f * sqrtf(0.5f * (diagonal.x * diagonal.x + diagonal.z * diagonal.z));
-    _boundingShape.setRadius(capsuleRadius);
-    _boundingShape.setHalfHeight(0.5f * diagonal.y - capsuleRadius);
+    _boundingCapsuleRadius = 0.5f * sqrtf(0.5f * (diagonal.x * diagonal.x + diagonal.z * diagonal.z));
+    _boundingCapsuleHeight = diagonal.y - 2.0f * _boundingCapsuleRadius;
 
     glm::vec3 rootPosition = _rig->getJointState(geometry.rootJointIndex).getPosition();
-    _boundingShapeLocalOffset = 0.5f * (totalExtents.maximum + totalExtents.minimum) - rootPosition;
+    _boundingCapsuleLocalOffset = 0.5f * (totalExtents.maximum + totalExtents.minimum) - rootPosition;
     _boundingRadius = 0.5f * glm::length(diagonal);
 }
 
@@ -687,30 +684,26 @@ void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float alpha
     auto deferredLighting = DependencyManager::get<DeferredLightingEffect>();
     Transform transform; // = Transform();
 
-    // draw a blue sphere at the capsule end point
-    glm::vec3 endPoint;
-    _boundingShape.getEndPoint(endPoint);
-    endPoint = endPoint + _translation;
-    transform.setTranslation(endPoint);
+    // draw a blue sphere at the capsule top point
+    glm::vec3 topPoint = _translation + _boundingCapsuleLocalOffset + (0.5f * _boundingCapsuleHeight) * glm::vec3(0.0f, 1.0f, 0.0f);
+    transform.setTranslation(topPoint);
     batch.setModelTransform(transform);
     deferredLighting->bindSimpleProgram(batch);
-    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
+    geometryCache->renderSphere(batch, _boundingCapsuleRadius, BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
                                 glm::vec4(0.6f, 0.6f, 0.8f, alpha));
 
-    // draw a yellow sphere at the capsule start point
-    glm::vec3 startPoint;
-    _boundingShape.getStartPoint(startPoint);
-    startPoint = startPoint + _translation;
-    glm::vec3 axis = endPoint - startPoint;
-    transform.setTranslation(startPoint);
+    // draw a yellow sphere at the capsule bottom point 
+    glm::vec3 bottomPoint = topPoint - glm::vec3(0.0f, -_boundingCapsuleHeight, 0.0f);
+    glm::vec3 axis = topPoint - bottomPoint;
+    transform.setTranslation(bottomPoint);
     batch.setModelTransform(transform);
     deferredLighting->bindSimpleProgram(batch);
-    geometryCache->renderSphere(batch, _boundingShape.getRadius(), BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
+    geometryCache->renderSphere(batch, _boundingCapsuleRadius, BALL_SUBDIVISIONS, BALL_SUBDIVISIONS,
                                 glm::vec4(0.8f, 0.8f, 0.6f, alpha));
 
     // draw a green cylinder between the two points
     glm::vec3 origin(0.0f);
-    Avatar::renderJointConnectingCone(batch, origin, axis, _boundingShape.getRadius(), _boundingShape.getRadius(),
+    Avatar::renderJointConnectingCone(batch, origin, axis, _boundingCapsuleRadius, _boundingCapsuleRadius,
                                       glm::vec4(0.6f, 0.8f, 0.6f, alpha));
 }
 

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -13,7 +13,6 @@
 #define hifi_SkeletonModel_h
 
 
-#include <CapsuleShape.h>
 #include <Model.h>
 
 class Avatar;
@@ -98,9 +97,9 @@ public:
 
     void computeBoundingShape(const FBXGeometry& geometry);
     void renderBoundingCollisionShapes(gpu::Batch& batch, float alpha);
-    float getBoundingShapeRadius() const { return _boundingShape.getRadius(); }
-    const CapsuleShape& getBoundingShape() const { return _boundingShape; }
-    const glm::vec3 getBoundingShapeOffset() const { return _boundingShapeLocalOffset; }
+    float getBoundingCapsuleRadius() const { return _boundingCapsuleRadius; }
+    float getBoundingCapsuleHeight() const { return _boundingCapsuleHeight; }
+    const glm::vec3 getBoundingCapsuleOffset() const { return _boundingCapsuleLocalOffset; }
 
     bool hasSkeleton();
 
@@ -157,8 +156,9 @@ private:
     
     Avatar* _owningAvatar;
 
-    CapsuleShape _boundingShape;
-    glm::vec3 _boundingShapeLocalOffset;
+    glm::vec3 _boundingCapsuleLocalOffset;
+    float _boundingCapsuleRadius;
+    float _boundingCapsuleHeight;
 
     glm::vec3 _defaultEyeModelPosition;
     int _standingFoot;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -23,8 +23,6 @@
 #include <PathUtils.h>
 #include <PerfStat.h>
 #include "PhysicsEntity.h"
-#include <ShapeCollider.h>
-#include <SphereShape.h>
 #include <ViewFrustum.h>
 
 #include "AbstractViewStateInterface.h"
@@ -223,10 +221,6 @@ void Model::setScaleInternal(const glm::vec3& scale) {
     if (relativeDeltaScale > ONE_PERCENT || scaleLength < EPSILON) {
         _scale = scale;
         initJointTransforms();
-        if (_shapes.size() > 0) {
-            clearShapes();
-            buildShapes();
-        }
     }
 }
 
@@ -1169,15 +1163,6 @@ QStringList Model::getJointNames() const {
     return isActive() ? _geometry->getFBXGeometry().getJointNames() : QStringList();
 }
 
-// virtual override from PhysicsEntity
-void Model::buildShapes() {
-    // TODO: figure out how to load/build collision shapes for general models
-}
-
-void Model::updateShapePositions() {
-    // TODO: implement this when we know how to build shapes for regular Models
-}
-
 class Blender : public QRunnable {
 public:
 
@@ -1348,8 +1333,6 @@ void Model::simulateInternal(float deltaTime) {
     glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset) * geometry.offset;
     _rig->simulateInternal(deltaTime, parentTransform, getTranslation(), getRotation());
 
-    _shapesAreDirty = !_shapes.isEmpty();
-
     glm::mat4 modelToWorld = glm::mat4_cast(_rotation);
     for (int i = 0; i < _meshStates.size(); i++) {
         MeshState& state = _meshStates[i];
@@ -1389,7 +1372,6 @@ bool Model::setJointPosition(int jointIndex, const glm::vec3& position, const gl
     glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset) * geometry.offset;
     if (_rig->setJointPosition(jointIndex, position, rotation, useRotation,
                                lastFreeIndex, allIntermediatesFree, alignment, priority, freeLineage, parentTransform)) {
-        _shapesAreDirty = !_shapes.isEmpty();
         return true;
     }
     return false;
@@ -1400,7 +1382,6 @@ void Model::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm:
     const QVector<int>& freeLineage = geometry.joints.at(endIndex).freeLineage;
     glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset) * geometry.offset;
     _rig->inverseKinematics(endIndex, targetPosition, targetRotation, priority, freeLineage, parentTransform);
-    _shapesAreDirty = !_shapes.isEmpty();
 }
 
 bool Model::restoreJointPosition(int jointIndex, float fraction, float priority) {
@@ -1413,10 +1394,6 @@ float Model::getLimbLength(int jointIndex) const {
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     const QVector<int>& freeLineage = geometry.joints.at(jointIndex).freeLineage;
     return _rig->getLimbLength(jointIndex, freeLineage, _scale, geometry.joints);
-}
-
-void Model::renderJointCollisionShapes(float alpha) {
-    // implement this when we have shapes for regular models
 }
 
 bool Model::maybeStartBlender() {
@@ -1484,7 +1461,6 @@ void Model::deleteGeometry() {
     _blendedVertexBuffers.clear();
     _rig->clearJointStates();
     _meshStates.clear();
-    clearShapes();
 
     _rig->deleteAnimations();
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -39,7 +39,6 @@
 class AbstractViewStateInterface;
 class QScriptEngine;
 
-class Shape;
 #include "RenderArgs.h"
 class ViewFrustum;
 
@@ -90,7 +89,6 @@ public:
     void removeFromScene(std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges);
     void renderSetup(RenderArgs* args);
     bool isRenderable() const { return !_meshStates.isEmpty() || (isActive() && _geometry->getMeshes().isEmpty()); }
-    virtual void renderJointCollisionShapes(float alpha);
 
     bool isVisible() const { return _isVisible; }
 
@@ -233,10 +231,6 @@ protected:
     /// \param position[out] position of joint in model-frame
     /// \return true if joint exists
     bool getJointPosition(int jointIndex, glm::vec3& position) const;
-
-    // virtual overrides from PhysicsEntity
-    virtual void buildShapes();
-    virtual void updateShapePositions();
 
     void setShowTrueJointTransforms(bool show) { _showTrueJointTransforms = show; }
 

--- a/libraries/render-utils/src/PhysicsEntity.cpp
+++ b/libraries/render-utils/src/PhysicsEntity.cpp
@@ -11,17 +11,10 @@
 
 #include "PhysicsEntity.h"
 
-#include "PlaneShape.h"
-#include "Shape.h"
-#include "ShapeCollider.h"
-#include "SphereShape.h"
-
 PhysicsEntity::PhysicsEntity() : 
     _translation(0.0f), 
     _rotation(), 
-    _boundingRadius(0.0f), 
-    _shapesAreDirty(true),
-    _enableShapes(false) {
+    _boundingRadius(0.0f) {
 }
 
 PhysicsEntity::~PhysicsEntity() {
@@ -29,143 +22,13 @@ PhysicsEntity::~PhysicsEntity() {
 
 void PhysicsEntity::setTranslation(const glm::vec3& translation) {
     if (_translation != translation) {
-        _shapesAreDirty = !_shapes.isEmpty();
         _translation = translation;
     }
 }
 
 void PhysicsEntity::setRotation(const glm::quat& rotation) {
     if (_rotation != rotation) {
-        _shapesAreDirty = !_shapes.isEmpty();
         _rotation = rotation;
     }
 }   
 
-void PhysicsEntity::setShapeBackPointers() {
-    for (int i = 0; i < _shapes.size(); i++) {
-        Shape* shape = _shapes[i];
-        if (shape) {
-            shape->setEntity(this);
-        }
-    }
-}
-
-void PhysicsEntity::setEnableShapes(bool enable) {
-    if (enable != _enableShapes) {
-        clearShapes();
-        _enableShapes = enable;
-        if (_enableShapes) {
-            buildShapes();
-        }
-    }
-}   
-
-void PhysicsEntity::clearShapes() {
-    for (int i = 0; i < _shapes.size(); ++i) {
-        delete _shapes[i];
-    }
-    _shapes.clear();
-}
-
-bool PhysicsEntity::findRayIntersection(RayIntersectionInfo& intersection) const {
-    return ShapeCollider::findRayIntersection(_shapes, intersection);
-}
-
-bool PhysicsEntity::findCollisions(const QVector<const Shape*> shapes, CollisionList& collisions) {
-    bool collided = false;
-    int numTheirShapes = shapes.size();
-    for (int i = 0; i < numTheirShapes; ++i) {
-        const Shape* theirShape = shapes[i];
-        if (!theirShape) {
-            continue;
-        }
-        int numOurShapes = _shapes.size();
-        for (int j = 0; j < numOurShapes; ++j) {
-            const Shape* ourShape = _shapes.at(j);
-            if (ourShape && ShapeCollider::collideShapes(theirShape, ourShape, collisions)) {
-                collided = true;
-            }
-        }
-    }
-    return collided;
-}
-
-bool PhysicsEntity::findSphereCollisions(const glm::vec3& sphereCenter, float sphereRadius, CollisionList& collisions) {
-    bool collided = false;
-    SphereShape sphere(sphereRadius, sphereCenter);
-    for (int i = 0; i < _shapes.size(); i++) {
-        Shape* shape = _shapes[i];
-        if (!shape) {
-            continue;
-        }
-        if (ShapeCollider::collideShapes(&sphere, shape, collisions)) {
-            CollisionInfo* collision = collisions.getLastCollision();
-            collision->_data = (void*)(this);
-            collision->_intData = i;
-            collided = true;
-        }
-    }
-    return collided;
-}
-
-bool PhysicsEntity::findPlaneCollisions(const glm::vec4& plane, CollisionList& collisions) {
-    bool collided = false;
-    PlaneShape planeShape(plane);
-    for (int i = 0; i < _shapes.size(); i++) {
-        if (_shapes.at(i) && ShapeCollider::collideShapes(&planeShape, _shapes.at(i), collisions)) {
-            CollisionInfo* collision = collisions.getLastCollision();
-            collision->_data = (void*)(this);
-            collision->_intData = i;
-            collided = true;
-        }
-    }
-    return collided;
-}
-
-// -----------------------------------------------------------
-// TODO: enforce this maximum when shapes are actually built.  The gotcha here is 
-// that the Model class (derived from PhysicsEntity) expects numShapes == numJoints, 
-// so we have to modify that code to be safe.
-const int MAX_SHAPES_PER_ENTITY = 256;
-
-// the first 256 prime numbers
-const int primes[256] = {
-      2,    3,    5,    7,   11,   13,   17,   19,   23,   29,
-     31,   37,   41,   43,   47,   53,   59,   61,   67,   71,
-     73,   79,   83,   89,   97,  101,  103,  107,  109,  113,
-    127,  131,  137,  139,  149,  151,  157,  163,  167,  173,
-    179,  181,  191,  193,  197,  199,  211,  223,  227,  229,
-    233,  239,  241,  251,  257,  263,  269,  271,  277,  281,
-    283,  293,  307,  311,  313,  317,  331,  337,  347,  349,
-    353,  359,  367,  373,  379,  383,  389,  397,  401,  409,
-    419,  421,  431,  433,  439,  443,  449,  457,  461,  463,
-    467,  479,  487,  491,  499,  503,  509,  521,  523,  541,
-    547,  557,  563,  569,  571,  577,  587,  593,  599,  601,
-    607,  613,  617,  619,  631,  641,  643,  647,  653,  659,
-    661,  673,  677,  683,  691,  701,  709,  719,  727,  733,
-    739,  743,  751,  757,  761,  769,  773,  787,  797,  809,
-    811,  821,  823,  827,  829,  839,  853,  857,  859,  863,
-    877,  881,  883,  887,  907,  911,  919,  929,  937,  941,
-    947,  953,  967,  971,  977,  983,  991,  997, 1009, 1013,
-   1019, 1021, 1031, 1033, 1039, 1049, 1051, 1061, 1063, 1069,
-   1087, 1091, 1093, 1097, 1103, 1109, 1117, 1123, 1129, 1151,
-   1153, 1163, 1171, 1181, 1187, 1193, 1201, 1213, 1217, 1223,
-   1229, 1231, 1237, 1249, 1259, 1277, 1279, 1283, 1289, 1291,
-   1297, 1301, 1303, 1307, 1319, 1321, 1327, 1361, 1367, 1373,
-   1381, 1399, 1409, 1423, 1427, 1429, 1433, 1439, 1447, 1451,
-   1453, 1459, 1471, 1481, 1483, 1487, 1489, 1493, 1499, 1511,
-   1523, 1531, 1543, 1549, 1553, 1559, 1567, 1571, 1579, 1583,
-   1597, 1601, 1607, 1609, 1613, 1619 };
-
-void PhysicsEntity::disableCollisions(int shapeIndexA, int shapeIndexB) {
-    if (shapeIndexA < MAX_SHAPES_PER_ENTITY && shapeIndexB < MAX_SHAPES_PER_ENTITY) {
-        _disabledCollisions.insert(primes[shapeIndexA] * primes[shapeIndexB]);
-    }
-}
-
-bool PhysicsEntity::collisionsAreEnabled(int shapeIndexA, int shapeIndexB) const {
-    if (shapeIndexA < MAX_SHAPES_PER_ENTITY && shapeIndexB < MAX_SHAPES_PER_ENTITY) {
-        return !_disabledCollisions.contains(primes[shapeIndexA] * primes[shapeIndexB]);
-    }
-    return false;
-}

--- a/libraries/render-utils/src/PhysicsEntity.h
+++ b/libraries/render-utils/src/PhysicsEntity.h
@@ -21,8 +21,6 @@
 #include <CollisionInfo.h>
 #include <RayIntersectionInfo.h>
 
-class Shape;
-
 class PhysicsEntity {
 
 public:
@@ -38,30 +36,10 @@ public:
     const glm::quat& getRotation() const { return _rotation; }
     float getBoundingRadius() const { return _boundingRadius; }
 
-    void setShapeBackPointers();
-
-    void setEnableShapes(bool enable);
-
-    virtual void buildShapes() = 0;
-    virtual void clearShapes();
-    const QVector<Shape*> getShapes() const { return _shapes; }
-
-    bool findRayIntersection(RayIntersectionInfo& intersection) const;
-    bool findCollisions(const QVector<const Shape*> shapes, CollisionList& collisions);
-    bool findSphereCollisions(const glm::vec3& sphereCenter, float sphereRadius, CollisionList& collisions);
-    bool findPlaneCollisions(const glm::vec4& plane, CollisionList& collisions);
-
-    void disableCollisions(int shapeIndexA, int shapeIndexB);
-    bool collisionsAreEnabled(int shapeIndexA, int shapeIndexB) const;
-
 protected:
     glm::vec3 _translation;
     glm::quat _rotation;
     float _boundingRadius;
-    bool _shapesAreDirty;
-    bool _enableShapes;
-    QVector<Shape*> _shapes;
-    QSet<int> _disabledCollisions;
 };
 
 #endif // hifi_PhysicsEntity_h


### PR DESCRIPTION
Cleaning up more legacy shape stuff in:  PhysicsEntity, Model, SkeletonModel, Avatar, and MyAvatar.

The ultimate goal will be to get rid of the **PhysicsEntity** class which has a misleading name -- it is now just a base class for Model that provides a transform, but the model's transform should probably be stored a different way (whatever has a Model should be providing the render transform, rather than storing it in the Model itself).

I offer this cleanup in case we want to merge it into the "rig" project early.  If this is not helpful we can close this one and I can create a new PR against highfidelity/master after the rig's first PR merge -- delaying this cleanup would probably make the first rig merge more manageable (less code changed).
