### PR TITLE
Remove cauterize code from Rig and move it back into Model.

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -273,7 +273,8 @@ private:
     void updatePosition(float deltaTime);
     void updateCollisionSound(const glm::vec3& penetration, float deltaTime, float frequency);
     void maybeUpdateBillboard();
-    
+    void initHeadBones();
+
     // Avatar Preferences
     bool _useFullAvatar = false;
     QUrl _fullAvatarURLFromPreferences;
@@ -286,6 +287,7 @@ private:
 
     RigPointer _rig;
     bool _prevShouldDrawHead;
+    std::unordered_set<int> _headBoneSet;
 };
 
 #endif // hifi_MyAvatar_h

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -51,7 +51,7 @@ SkeletonModel::~SkeletonModel() {
 void SkeletonModel::initJointStates(QVector<JointState> states) {
     const FBXGeometry& geometry = _geometry->getFBXGeometry();
     glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset) * geometry.offset;
-    _boundingRadius = _rig->initJointStates(states, parentTransform, geometry.neckJointIndex);
+    _boundingRadius = _rig->initJointStates(states, parentTransform);
 
     // Determine the default eye position for avatar scale = 1.0
     int headJointIndex = _geometry->getFBXGeometry().headJointIndex;
@@ -174,14 +174,6 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
         } else {
             restoreRightHandPosition(HAND_RESTORATION_RATE, PALM_PRIORITY);
         }
-    }
-
-    // if (_isFirstPerson) {
-    //     cauterizeHead();
-    //     updateClusterMatrices();
-    // }
-    if (_rig->getJointsAreDirty()) {
-        updateClusterMatrices();
     }
 }
 

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -75,7 +75,7 @@ public:
                             float priority = 1.0f, bool loop = false, bool hold = false, float firstFrame = 0.0f,
                             float lastFrame = FLT_MAX, const QStringList& maskedJoints = QStringList(), bool startAutomatically = false);
 
-    float initJointStates(QVector<JointState> states, glm::mat4 parentTransform, int neckJointIndex);
+    float initJointStates(QVector<JointState> states, glm::mat4 parentTransform);
     bool jointStatesEmpty() { return _jointStates.isEmpty(); };
     int getJointStateCount() const { return _jointStates.size(); }
     int indexOfJoint(const QString& jointName) ;
@@ -131,10 +131,6 @@ public:
     virtual void updateJointState(int index, glm::mat4 parentTransform) = 0;
     virtual void updateFaceJointState(int index, glm::mat4 parentTransform) = 0;
 
-    virtual void setFirstPerson(bool isFirstPerson);
-    virtual bool getIsFirstPerson() const { return _isFirstPerson; }
-
-    bool getJointsAreDirty() { return _jointsAreDirty; }
     void setEnableRig(bool isEnabled) { _enableRig = isEnabled; }
 
  protected:
@@ -143,13 +139,6 @@ public:
     QList<AnimationHandlePointer> _animationHandles;
     QList<AnimationHandlePointer> _runningAnimations;
 
-    JointState maybeCauterizeHead(int jointIndex) const;
-    void initHeadBones();
-    bool _isFirstPerson = false;
-    std::vector<int> _headBones;
-    bool _jointsAreDirty = false;
-    int _neckJointIndex = -1;
-    
     bool _enableRig;
     bool _isWalking;
     bool _isTurning;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -18,6 +18,7 @@
 #include <QMutex>
 
 #include <unordered_map>
+#include <unordered_set>
 #include <functional>
 
 #include <AABox.h>
@@ -172,6 +173,9 @@ public:
     /// \return true if joint exists
     bool getJointRotation(int jointIndex, glm::quat& rotation) const;
 
+    /// Returns the index of the parent of the indexed joint, or -1 if not found.
+    int getParentJointIndex(int jointIndex) const;
+
     void inverseKinematics(int jointIndex, glm::vec3 position, const glm::quat& rotation, float priority);
 
     /// Returns the extents of the model in its bind pose.
@@ -186,6 +190,12 @@ public:
     /// enables/disables scale to fit behavior, the model will be automatically scaled to the specified largest dimension
     bool getIsScaledToFit() const { return _scaledToFit; } /// is model scaled to fit
     const glm::vec3& getScaleToFitDimensions() const { return _scaleToFitDimensions; } /// the dimensions model is scaled to
+
+    void setCauterizeBones(bool flag) { _cauterizeBones = flag; }
+    bool getCauterizeBones() const { return _cauterizeBones; }
+
+    const std::unordered_set<int>& getCauterizeBoneSet() const { return _cauterizeBoneSet; }
+    void setCauterizeBoneSet(const std::unordered_set<int>& boneSet) { _cauterizeBoneSet = boneSet; }
 
 protected:
 
@@ -217,9 +227,6 @@ protected:
 
     /// Clear the joint states
     void clearJointState(int index);
-
-    /// Returns the index of the parent of the indexed joint, or -1 if not found.
-    int getParentJointIndex(int jointIndex) const;
 
     /// Returns the index of the last free ancestor of the indexed joint, or -1 if not found.
     int getLastFreeJointIndex(int jointIndex) const;
@@ -255,9 +262,12 @@ protected:
     class MeshState {
     public:
         QVector<glm::mat4> clusterMatrices;
+        QVector<glm::mat4> cauterizedClusterMatrices;
     };
 
     QVector<MeshState> _meshStates;
+    std::unordered_set<int> _cauterizeBoneSet;
+    bool _cauterizeBones;
 
     // returns 'true' if needs fullUpdate after geometry change
     bool updateGeometry();


### PR DESCRIPTION
- cauterize code is used as at render time and is not dependent on
  the jointStates.
- MyAvatar now initializes the bone set used for cauterization and
  makes the decision to perform cauterization in preRender.
